### PR TITLE
Fix User -> Project assignation

### DIFF
--- a/app/services/github/project_updater_service.rb
+++ b/app/services/github/project_updater_service.rb
@@ -16,11 +16,10 @@ module Github
         name: project.name_with_owner,
         url: project.url,
         project_created_at: project.created_at
-      ) do |current_repository|
-        current_repository.project_last_modified = project.updated_at
-        current_repository.users << user if !current_repository.users.where(id: user.id).any?
-        current_repository.save!
-      end
+      )
+      repository.project_last_modified = project.updated_at
+      repository.users << user if !repository.users.where(id: user.id).any?
+      repository.save!
       repository
     end
   end


### PR DESCRIPTION
- Changes user asignation when a project is created or found:
There was an issue where only one user was attached to a project, it was
due to the find_or_create_by method, there was a block given, that block
was asigning an user to a project only when the 'created' method was
executed (the first time), causing more user that contributed to the
same project to not being assigned to the same project as well.